### PR TITLE
Improve support for modifying GEDCOM data

### DIFF
--- a/gedcom/__init__.py
+++ b/gedcom/__init__.py
@@ -103,7 +103,7 @@ class Gedcom:
         level = int(line_parts[0])
         pointer = line_parts[1].rstrip(' ')
         tag = line_parts[2]
-        value = line_parts[3].lstrip(' ')
+        value = line_parts[3][1:]
 
         # Check level: should never be more than one higher than previous line.
         if level > last_elem.level() + 1:

--- a/gedcom/__init__.py
+++ b/gedcom/__init__.py
@@ -393,6 +393,14 @@ class Element:
         """ Check if this element is a family """
         return self.tag() == "FAM"
 
+    def is_file(self):
+        """ Check if this element is a file """
+        return self.tag() == "FILE"
+
+    def is_object(self):
+        """ Check if this element is an object """
+        return self.tag() == "OBJE"
+
     # criteria matching
 
     def criteria_match(self,criteria):

--- a/gedcom/__init__.py
+++ b/gedcom/__init__.py
@@ -28,6 +28,7 @@ __all__ = ["Gedcom", "Element", "GedcomParseError"]
 
 # Global imports
 import re
+from sys import version_info
 
 class Gedcom:
     """Parses and manipulates GEDCOM 5.5 format data
@@ -108,7 +109,7 @@ class Gedcom:
         line_num = 1
         last_elem = self.__element_top
         for line in gedcom_file:
-            last_elem = self.__parse_line(line_num, line, last_elem)
+            last_elem = self.__parse_line(line_num, line.decode('utf-8'), last_elem)
             line_num += 1
 
     def __parse_line(self, line_num, line, last_elem):
@@ -342,7 +343,10 @@ class Gedcom:
 
     def save_gedcom(self, open_file):
         """ Save GEDCOM data to a file. """
-        open_file.write(self.root().get_individual())
+        if version_info[0] >= 3:
+            open_file.write(self.root().get_individual())
+        else:
+            open_file.write(self.root().get_individual().encode('utf-8'))
 
 
 class GedcomParseError(Exception):
@@ -751,12 +755,18 @@ class Element:
 
     def get_individual(self):
         """ Return this element and all of its sub-elements """
-        result = str(self)
+        result = self.__unicode__()
         for e in self.children():
             result += e.get_individual()
         return result
 
     def __str__(self):
+        if version_info[0] >= 3:
+            return self.__unicode__()
+        else:
+            return self.__unicode__().encode('utf-8')
+
+    def __unicode__(self):
         """ Format this element as its original string """
         if self.level() < 0:
             return ''

--- a/gedcom/__init__.py
+++ b/gedcom/__init__.py
@@ -161,7 +161,6 @@ class Gedcom:
             parent_elem = parent_elem.parent()
         # Add child to parent & parent to child.
         parent_elem.add_child(element)
-        element.add_parent(parent_elem)
         return element
 
     def __build_list(self, e, elist):
@@ -434,15 +433,19 @@ class Element:
         """ Create and return a new child element of this element """
         c = Element(self.level() + 1, pointer, tag, value, self.__crlf)
         self.add_child(c)
-        c.add_parent(self)
         return c
 
     def add_child(self,element):
         """ Add a child element to this element """
         self.children().append(element)
+        element.add_parent(self)
         
     def add_parent(self,element):
-        """ Add a parent element to this element """
+        """ Add a parent element to this element
+
+        There's usually no need to call this method manually,
+        add_child() calls it automatically.
+        """
         self.__parent = element
 
     def is_individual(self):

--- a/gedcom/__init__.py
+++ b/gedcom/__init__.py
@@ -310,8 +310,11 @@ class Gedcom:
     def print_gedcom(self):
         """Write GEDCOM data to stdout."""
         from sys import stdout
-        for element in self.element_list():
-            stdout.write(element)
+        self.save_gedcom(stdout)
+
+    def save_gedcom(self, open_file):
+        """ Save GEDCOM data to a file. """
+        open_file.write(self.root().get_individual())
 
 
 class GedcomParseError(Exception):

--- a/gedcom/__init__.py
+++ b/gedcom/__init__.py
@@ -386,6 +386,10 @@ class Element:
         """ Return the value of this element """
         return self.__value
 
+    def set_value(self, value):
+        """ Set the value of this element """
+        self.__value = value
+
     def children(self):
         """ Return the child elements of this element """
         return self.__children

--- a/gedcom/__init__.py
+++ b/gedcom/__init__.py
@@ -398,6 +398,13 @@ class Element:
         """ Return the parent element of this element """
         return self.__parent
 
+    def new_child(self,tag,pointer='',value=''):
+        """ Create and return a new child element of this element """
+        c = Element(self.level() + 1, pointer, tag, value, self.__crlf)
+        self.add_child(c)
+        c.add_parent(self)
+        return c
+
     def add_child(self,element):
         """ Add a child element to this element """
         self.children().append(element)

--- a/gedcom/__init__.py
+++ b/gedcom/__init__.py
@@ -63,6 +63,20 @@ class Gedcom:
         """
         return self.__element_dict
 
+    def root(self):
+        """ Returns a virtual root element containing all logical records as children
+
+        When printed, this element converts to an empty string.
+        """
+        return self.__element_top
+
+    def records(self):
+        """ Return a list of logical records in the GEDCOM file.
+
+        By default, elements are in the same order as they appeared in the file.
+        """
+        return self.root().children()
+
     # Private methods
 
     def __parse(self, filepath):
@@ -702,6 +716,8 @@ class Element:
 
     def __str__(self):
         """ Format this element as its original string """
+        if self.level() < 0:
+            return ''
         result = str(self.level())
         if self.pointer() != "":
             result += ' ' + self.pointer()


### PR DESCRIPTION
Hello Madeleine,

with these commits, users of your library can
- handle Unicode correctly, using UTF-8 for I/O
- access root- and top-level elements directly
- add and remove elements of the data tree without getting out of sync with element_list() and element_dict()
- modify existing elements' values
- read and write long/multiple lines of text (CONC/CONT) transparently
- print or save an exact copy of a previously loaded GEDCOM file

Best regards,
Andreas
