### PR TITLE
Fix mother/father relationship tag

### DIFF
--- a/gedcom/__init__.py
+++ b/gedcom/__init__.py
@@ -233,10 +233,10 @@ class Gedcom:
                     if famrec.tag() == "CHIL" and famrec.value() == indi.pointer():
                         for chilrec in famrec.children():
                             if chilrec.value() == "Natural":
-                                if chilrec.tag() == "_FREL":
+                                if chilrec.tag() == "_MREL":
                                     parents = (parents + 
                                                self.get_family_members(family, "WIFE"))
-                                elif chilrec.tag() == "_MREL":
+                                elif chilrec.tag() == "_FREL":
                                     parents = (parents +
                                                self.get_family_members(family, "HUSB"))
             else:


### PR DESCRIPTION
Ran into this when writing code to people not connected to my main tree.

per http://www.gencom.org.nz/GEDCOM_tags.html
- MREL is relationship to mother
- FREL is relationship to father

This is consistent with what ancestry.com exports